### PR TITLE
Fix basename and extension split when strip name contain multiple dots.

### DIFF
--- a/Blender_2.76/blue_velvet.py
+++ b/Blender_2.76/blue_velvet.py
@@ -110,7 +110,7 @@ def getAudioTimeline(ar, fps):
             # "anything.001" or "anything.wav", the script would fail with the
             # error "ValueError: need more than 1 value to unpack"
             try:
-                base_name, ext = i.name.split(".")
+                base_name, ext = i.name.rsplit(".", maxsplit = 1)
             except ValueError:
                 base_name = i.name
                 foo, ext = name.split(".")


### PR DESCRIPTION
Because last export my filename contain basename.number.letter.ext so the standard split contains 2+ elements. So I fix it with rsplit.