### PR TITLE
Fix bug for strip names ending with "."

### DIFF
--- a/Blender_2.78/blue_velvet.py
+++ b/Blender_2.78/blue_velvet.py
@@ -151,7 +151,7 @@ def getAudioTimeline(ar, fps):
             else:
                 audioData['channels'] = 1
 
-            if ("." + ext).lower() in validExts:
+            if ("." + ext).lower() in validExts or ext=='':
                 audioData['nExt'] = 1
                 audioData['ardour_name'] = "%s.%i" % (audioData['base_name'],
                                                       audioData['nExt'])


### PR DESCRIPTION
The plugin throws an error if some strip name is ending with "." character:

```
Traceback (most recent call last):
 File "/home/data/tools/blender-plugins/addons/blue_velvet.py", line 675, in execute audiosFolder)
 File "/home/data/tools/blender-plugins/addons/blue_velvet.py", line 510, in createXML sources, repeated, tracks, idCounter = getAudioTimeline(audioRate, fps)
 File "/home/data/tools/blender-plugins/addons/blue_velvet.py", line 164, in getAudioTimeline audioData['nExt'] = int(ext)
 ValueError: invalid literal for int() with base 10: ''
```

Fix attached.