### PR TITLE
Blue Velvet: fix left channel overwritten by right channel

### DIFF
--- a/Blender_2.79/blue_velvet.py
+++ b/Blender_2.79/blue_velvet.py
@@ -562,10 +562,12 @@ def createXML(sources, startFrame, endFrame, fps, timecode, audioRate,
     stereoSources = []
     numAdded = 0
     for source in sources:
-        if (source['channels'] == 1):
-            source['id'] = int(source['id'] + idCounter)
-            createAudioSources(Session, source, 1)
-            stereoSources.append(source)
+        if (source['channels'] == 1) and not any (source['base_name'] ==
+                d['base_name'] for d in stereoSources):
+            newsrc = source.copy()
+            newsrc['id'] = int(newsrc['id'] + idCounter)
+            createAudioSources(Session, newsrc, 1)
+            stereoSources.append(newsrc)
             numAdded += 1
     idCounter += numAdded
 

--- a/Blender_2.79/blue_velvet.py
+++ b/Blender_2.79/blue_velvet.py
@@ -560,12 +560,14 @@ def createXML(sources, startFrame, endFrame, fps, timecode, audioRate,
 
     # create another sources' entry for stereo files
     stereoSources = []
+    numAdded = 0
     for source in sources:
         if (source['channels'] == 1):
             source['id'] = int(source['id'] + idCounter)
             createAudioSources(Session, source, 1)
             stereoSources.append(source)
-            idCounter += 1
+            numAdded += 1
+    idCounter += numAdded
 
     # create playlists (tracks)
     for track in tracks:

--- a/Blender_2.79/blue_velvet.py
+++ b/Blender_2.79/blue_velvet.py
@@ -155,8 +155,11 @@ def getAudioTimeline(ar, fps):
                 audioData['nExt'] = 1
                 audioData['ardour_name'] = "%s.%i" % (audioData['base_name'],
                                                       audioData['nExt'])
-                timelineSources.append(audioData)
-                idCounter += 1
+                if any (d['base_name'] == base_name for d in timelineSources):
+                    timelineRepeated.append(audioData)
+                else:
+                    timelineSources.append(audioData)
+                    idCounter += 1
             else:
                 audioData['nExt'] = int(ext)
                 audioData['ardour_name'] = "%s.%i" % (audioData['base_name'],


### PR DESCRIPTION
I have noticed strange sound changes for strips with repeated sources when listening in Ardour. After analyzing the generated .ardour file, I saw the second strip had `master-source-0` and `master-source-1` point to the same source! The same with `source-0` and `source-1`. The right channel was being used in both channels and that's why it sounded strange. The dict was being overwritten with the id of the right channel source.